### PR TITLE
add /webhook endpoint

### DIFF
--- a/controllers/sweep_task.js
+++ b/controllers/sweep_task.js
@@ -23,6 +23,9 @@ var SweepTaskFsm = machina.BehavioralFsm.extend({
 			},
 			"msg:done": function(task) {
 				this.handle(task, "complete");
+			},
+			"webhook:done": function(task) {
+				this.handle(task, "complete");
 			}
 		},
 	}

--- a/controllers/task.js
+++ b/controllers/task.js
@@ -65,6 +65,9 @@ var TaskFsm = new machina.BehavioralFsm({
 	},
 	userMessage: function(task, message) {
 		this.handle(task, 'msg:' + message);
+	},
+	webhook: function(task, message) {
+		this.handle(task, 'webhook:' + message);
 	}
 });
 

--- a/handlers.js
+++ b/handlers.js
@@ -163,6 +163,26 @@ module.exports.dispatchMessage = (payload, reply) => {
 	})
 }
 
+module.exports.handleWebhook = (req) => {
+	return Volunteer.where({fbid: req.body.wid})
+	.fetch({withRelated: ['deployment']})
+	.then(vol => {
+		if (vol) {
+			return getVolTask(vol)
+		} else {
+			throw new Error(`Could not find volunteer with id ${req.body.wid}.`)
+		}
+	})
+	.then(function(task) {
+		if (task) {
+			return TaskController.webhook(task, req.body.message);
+		} else {
+			throw new Error("Could not find active task.")
+		}
+	})
+}
+
+
 module.exports.dispatchPostback = (payload, reply) => {
 	const postback = JSON.parse(payload.postback.payload)
 	if (postback.type in postbackHandlers) {

--- a/routes.js
+++ b/routes.js
@@ -35,6 +35,19 @@ router.post('/consent', bodyParser.urlencoded({extended: true}), function(req, r
 	})
 })
 
+router.post('/webhook', bodyParser.urlencoded({extended: true}), function(req,res,next) {
+	if (!req.body.wid || !req.body.message) {
+		return res.status(400).send('message and wid are required');
+	}
+	handlers.handleWebhook(req).then(function(err) {
+		if (!err) {
+			res.send('OK');
+		} else {
+			res.status(400).send(err);
+		}
+	})
+});
+
 // Batch add tasks.
 router.post('/tasks', bodyParser.json(), function(req, res, next) {
 	let templates = _.uniq(_.map(req.body, 'template_type'))


### PR DESCRIPTION
This allows a message to be sent to /webhook with URL encoded params `wid` for worker id and `message`. The message will be passed along to the TaskController FSM for that volunteer, if the volunteer exists and has an active task.